### PR TITLE
Add Focus Management section content

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -172,13 +172,35 @@ id="start-new-app"
   </ol>
 </p>
 
-{{!-- 
 <EaDivider />
 <h2 id="section-focus-management">
   <a href="">&sect;</a> Focus Management
 </h2>
-<p>Coming Soon!</p>
---}}
+<p>Focus determines which part of your application receives events from the keyboard and clipboard at any given time. Good focus management can provide a better experience for all of your users, but is particularly critical for those who may navigate exclusively via their keyboard or other input device, such as a switch device.</p>
+
+<h3>Included in the browser</h3>
+<p>Browsers come with built-in focus behavior based on the type of elements used. Interactive elements like buttons and text fields are implicitly focusable, which means that they are automatically inserted into the tab order of the page and come with built-in event handling.</p>
+<p>Non-interactive elements purposely do not receive focus without developer intervention, because no action from the user is expected.</p>
+
+<h3>Screenreaders: browsing mode vs focus mode</h3>
+<p>Screenreaders offer users different ways of navigating your web app; the most common modes are <em>browse</em> and <em>focus</em>.</p>
+<p>In browse mode, users can place the screen reader cursor on any element in a webpage, including those which are not focusable. This is possible because the screen reader cursor (or focus) is distinct from the visible focus you can see in the browser. The screen reader intercepts keystrokes and uses them to control sophisticated navigation between elements, such as jumping between heading elements using the <code>H</code> key or links by pressing <code>K</code>.</p>
+<p>It's not possible, however, to interact with the page while in browse mode. Instead, users can switch to focus mode which will pass keystrokes directly to the browser. Navigation in focus mode behaves like keyboard-only navigation (<code>Tab</code> will jump to the next focusable element, or <code>Shift</code> + <code>Tab</code> to the previous).</p>
+
+<h3>Focus Order</h3>
+<p>It's important to keep focus behavior logical and predictable. This can require extra care when user interaction modifies the tabbable order of elements, such as by opening or closing a modal. In the case of a modal, focus should move to an element inside the modal while open (and not be permitted to reach the page below). Conversely, closing the modal should revert focus back to the originating element that triggered opening it. </p>
+
+<h3>How focus works in Ember</h3>
+<p>Coming soon </p>
+
+<h3>Helpful Addons </h3>
+<p>
+  <ol>
+    <li><a href="https://github.com/ember-a11y/ember-component-focus" rel="external">ember-component-focus</a></li>
+    <li><a href="https://github.com/melsumner/e-a11y-modal" rel="external">e-a11y-modal</a></li>
+  </ol>
+</p>
+
 
 {{!-- 
 <EaDivider />

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -179,8 +179,8 @@ id="start-new-app"
 <p>Focus determines which part of your application receives events from the keyboard and clipboard at any given time. Good focus management can provide a better experience for all of your users, but is particularly critical for those who may navigate exclusively via their keyboard or other input device, such as a switch device.</p>
 
 <h3>Included in the browser</h3>
-<p>Browsers come with built-in focus behavior based on the type of elements used. Interactive elements like buttons and text fields are implicitly focusable, which means that they are automatically inserted into the tab order of the page and come with built-in event handling.</p>
-<p>Non-interactive elements purposely do not receive focus without developer intervention, because no action from the user is expected.</p>
+<p>Browsers come with built-in focus behavior based on the type of elements used. Interactive elements like buttons and input fields are implicitly focusable, which means that they are automatically inserted into the tab order of the page and come with built-in event handling.</p>
+<p>Non-interactive elements purposely do not receive focus without developer intervention, because no action from the user is expected. In Ember, we help you stay on the well-lit path and disallow interactivity on non-interactive elements, through the no-invalid-interactive rule in <a href="https://github.com/ember-template-lint/ember-template-lint" rel="external">ember-template-lint</a>.</p>
 
 <h3>Screenreaders: browsing mode vs focus mode</h3>
 <p>Screenreaders offer users different ways of navigating your web app; the most common modes are <em>browse</em> and <em>focus</em>.</p>
@@ -188,10 +188,9 @@ id="start-new-app"
 <p>It's not possible, however, to interact with the page while in browse mode. Instead, users can switch to focus mode which will pass keystrokes directly to the browser. Navigation in focus mode behaves like keyboard-only navigation (<code>Tab</code> will jump to the next focusable element, or <code>Shift</code> + <code>Tab</code> to the previous).</p>
 
 <h3>Focus Order</h3>
-<p>It's important to keep focus behavior logical and predictable. This can require extra care when user interaction modifies the tabbable order of elements, such as by opening or closing a modal. In the case of a modal, focus should move to an element inside the modal while open (and not be permitted to reach the page below). Conversely, closing the modal should revert focus back to the originating element that triggered opening it. </p>
-
+<p><a href="https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html" rel="external">Focus order</a> is an important part of ensuring that your Ember application is accessible. As such, it's vital that focus behavior is logical and predictable, providing <a href="https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence.html" rel="external">meaningful sequence</a>. This can require extra care when user interaction modifies the tabbable order of elements, such as by opening or closing a modal. In the case of a modal, focus should move to an element inside the modal while open (and not be permitted to reach the page below). Conversely, closing the modal should revert focus back to the originating element that triggered opening it. </p>
 <h3>How focus works in Ember</h3>
-<p>Coming soon </p>
+<p>Coming soon!</p>
 
 <h3>Helpful Addons </h3>
 <p>


### PR DESCRIPTION
Content to address: https://github.com/MelSumner/ember-a11y-for/issues/8

Add a section on focus management. It should include:

- [x]  what the browser naturally gives you
- [x]  browsing mode vs focus mode in screen readers
- [x]  focus should return to the place it came from
- [ ]  how focus works in Ember
- [x]  addons to consider